### PR TITLE
FIX: Remove limitation on measure_average function

### DIFF
--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -169,10 +169,9 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
                 logger.debug("measure_average on det=%s, mot=%s, sys=%s",
                              detectors[index], motors[index], full_system)
                 avgs = (yield from measure_average([detectors[index],
-                                                   motors[index]]
-                                                  + full_system,
-                                                  [detector_fields[index]],
-                                                  num=averages[index]))
+                                                    motors[index]]
+                                                    + full_system,
+                                                    num=averages[index]))
 
                 pos = avgs[field_prepend(detector_fields[index],
                                          detectors[index])]

--- a/pswalker/plan_stubs.py
+++ b/pswalker/plan_stubs.py
@@ -155,7 +155,6 @@ def verify_all(detectors, target_fields, target_values, tolerances,
             logger.error(err)
             raise RuntimeError(err)
         avgs = yield from measure_average([det] + other_readers,
-                                          [fld] + other_fields,
                                           num=average, delay=delay)
         #Check the tolerance of detector measurement
         ok_list.append(abs(avgs[field_prepend(fld,det)] - val) < tol)

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -74,10 +74,8 @@ def test_measure_average(RE, one_bounce_system):
     col_c = collector(det.name + '_detector_stats2_centroid_x', centroids)
     col_r = collector(mot.name + '_pitch',    readbacks)
     #Run plan
-    RE(run_wrapper(measure_average([det, mot],
-                                   ['detector_stats2_centroid_x','pitch'],
-                                   delay=0.1, num=5)),
-       subs={'event':[col_c, col_r]})
+    RE(run_wrapper(measure_average([det, mot], delay=0.1, num=5)),
+                   subs={'event':[col_c, col_r]})
     #Check events
     assert centroids == [250.,250.,250.,250.,250.]
     assert readbacks == [0.,0.,0.,0.,0.]
@@ -86,9 +84,7 @@ def test_measure_average(RE, one_bounce_system):
     centroids.clear()
     readbacks.clear()
     #Run with array of delays
-    RE(run_wrapper(measure_average([det, mot],
-                                   ['detector_stats2_centroid_x','pitch'],
-                                   delay=[0.1], num=2)),
+    RE(run_wrapper(measure_average([det, mot], delay=[0.1], num=2)),
        subs={'event':[col_c, col_r]})
     #Check events
     assert centroids == [250., 250.]
@@ -96,9 +92,7 @@ def test_measure_average(RE, one_bounce_system):
 
     #Invalid delay settings
     with pytest.raises(ValueError):
-        RE(run_wrapper(measure_average([det, mot],
-                                       ['detector_stats2_centroid_x','pitch'],
-                                       delay=[0.1], num=3)))
+        RE(run_wrapper(measure_average([det, mot], delay=[0.1], num=3)))
 
 
 def test_measure_average_system(RE, lcls_two_bounce_system):
@@ -111,7 +105,6 @@ def test_measure_average_system(RE, lcls_two_bounce_system):
     col_r = collector(m1.name + '_pitch',    readbacks)
 
     RE(run_wrapper(measure_average([y1, m1, y2, m2],
-                                   ['detector_stats2_centroid_x','pitch'],
                                    delay=0.1, num=5)),
        subs={'event':[col_c, col_r]})
 


### PR DESCRIPTION
 No longer specify the target_fields in measure_average, just average all the fields from the `read`. Closes #2 

Att: @n-wbrown