### PR TITLE
Oneyagipynb

### DIFF
--- a/notebooks/run_skywalker.ipynb
+++ b/notebooks/run_skywalker.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Skywalker algorithm against the two mirror system"
+    "# Skywalker algorithm against the lcls mirror systems"
    ]
   },
   {
@@ -16,9 +16,15 @@
    "outputs": [],
    "source": [
     "SIMULATION = True\n",
+    "ALIGNMENT = 'HOMS'\n",
+    "#ALIGNMENT = 'MEC'\n",
+    "#ALIGNMENT = 'MFX'\n",
+    "#ALIGNMENT = 'XCS'\n",
     "\n",
-    "goal1 = 210 # Target pixel on first imager. NOTE: Don't do the math for flipped image\n",
-    "goal2 = 270 # Target pixel on second imager. NOTE: Don't do the math for flipped image\n",
+    "alignment_goals = dict(HOMS=[210, 270],\n",
+    "                       MEC=[270],\n",
+    "                       MFX=[270],\n",
+    "                       XCS=[270, 270])\n",
     "first_steps = 10 # Naive first step for the parameters search\n",
     "tolerances = 2.0 # Tolerance of each target in Pixels\n",
     "average = 1 # Number of shots to average over\n",
@@ -26,9 +32,7 @@
     "\n",
     "# PARAMETERS FOR SIMULATION ONLY\n",
     "centroid_noise = 5.0 # Noise level of centroid measurements\n",
-    "infinite_yag = False # Assume all yags are infinitely large\n",
-    "\n",
-    "goals = [goal1, goal2]"
+    "infinite_yag = False # Assume all yags are infinitely large"
    ]
   },
   {
@@ -65,7 +69,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2017-07-20 15:45:30,268 - INFO - Patching 2 pim(s)\n"
+      "2017-07-26 12:59:22,071 - INFO - pswalker.examples - Patching 2 pim(s)\n",
+      "2017-07-26 12:59:22,072 - INFO - pswalker.examples - Patching 1 pim(s)\n"
      ]
     }
    ],
@@ -83,10 +88,11 @@
     "\n",
     "#Create basic configuration\n",
     "logging.basicConfig(level=log_level,\n",
-    "                format='%(asctime)s - %(levelname)s - %(message)s')\n",
+    "                format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')\n",
     "\n",
     "from pswalker.examples  import patch_pims\n",
     "from pswalker.skywalker import skywalker\n",
+    "from pswalker.plans import walk_to_pixel\n",
     "\n",
     "#Instantiate simulation\n",
     "if not SIMULATION:\n",
@@ -104,6 +110,7 @@
     "    hx2 = system['hx2']\n",
     "    dg3 = system['dg3']\n",
     "    mfxdg1 = system['mfxdg1']\n",
+    "    mecy1 = system['mecy1']\n",
     "    m1 = m1h\n",
     "    m2 = m2h\n",
     "    y1 = hx2\n",
@@ -112,37 +119,53 @@
     "    s = source.Undulator('test_undulator')\n",
     "    m1 = mirror.OffsetMirror('test_m1h', z=90.510, alpha=0.0014)\n",
     "    m2 = mirror.OffsetMirror('test_m2h', x=0.0317324, z=101.843, alpha=0.0014)\n",
+    "    xrtm2 = mirror.OffsetMirror('test_xrtm2', x=0.0317324, z=200, alpha=0.0014)\n",
     "    y1 = pim.PIM('test_p3h', x=0.0317324, z=103.660,\n",
     "             zero_outside_yag= not infinite_yag)\n",
     "    y2 = pim.PIM('test_dg3', x=0.0317324, z=375.000,\n",
     "             zero_outside_yag= not infinite_yag)\n",
+    "    mecy1 = pim.PIM('test_mecy1', x=0.0317324, z=350,\n",
+    "             zero_outside_yag= not infinite_yag)\n",
+    "    mfxdg1 = mecy1\n",
     "    patch_pims([y1, y2], mirrors=[m1, m2], source=s)\n",
+    "    patch_pims([mecy1], mirrors=[xrtm2], source=s)\n",
     "\n",
     "    #Add noise\n",
     "    y1.centroid_noise = centroid_noise\n",
-    "    y2.centroid_noise = centroid_noise\n"
+    "    y2.centroid_noise = centroid_noise\n",
+    "    mecy1.centroid_noise = centroid_noise\n",
+    "\n",
+    "alignment_yags = dict(HOMS=[y1, y2],\n",
+    "                      MEC=[mecy1],\n",
+    "                      MFX=[mfxdg1],\n",
+    "                      XCS=['pbty', 'xcssb1y'])\n",
+    "alignment_mots = dict(HOMS=[m1, m2],\n",
+    "                      MEC=[xrtm2],\n",
+    "                      MFX=[xrtm2],\n",
+    "                      XCS=['xrtm1', 'xrtm3'])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Create Skywalker plan\n",
-    "plan = skywalker([y1, y2], [m1, m2], 'detector_stats2_centroid_x', 'pitch',\n",
-    "             goals, first_steps=first_steps, tolerances=tolerances,\n",
-    "             averages=average, timeout=10)\n"
+    "yags = alignment_yags[ALIGNMENT]\n",
+    "mots = alignment_mots[ALIGNMENT]\n",
+    "goals = alignment_goals[ALIGNMENT]\n",
+    "det_rbv = 'detector_stats2_centroid_x'\n",
+    "mot_rbv = 'pitch'\n",
+    "plan = skywalker(yags, mots, det_rbv, mot_rbv,\n",
+    "        goals, first_steps=first_steps, tolerances=tolerances,\n",
+    "        averages=average, timeout=10)  "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Create RunEngine\n",
@@ -161,128 +184,31 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2017-07-20 15:46:02,662 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 2992.5109704925367\n",
-      "2017-07-20 15:46:02,664 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:02,665 - INFO - Walking motor, error after step #0 -> -2782.5109704925367\n",
-      "2017-07-20 15:46:02,665 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:02,777 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 2970.1960811994313\n",
-      "2017-07-20 15:46:02,778 - INFO - Walking motor, error after step #1 -> -2760.1960811994313\n",
-      "2017-07-20 15:46:02,779 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:02,780 - INFO - Adjusting motor MIRR:TST:test_m1h to position 1246.9316150448226\n",
-      "2017-07-20 15:46:02,895 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 231.1586845932672\n",
-      "2017-07-20 15:46:02,896 - INFO - Walking motor, error after step #2 -> -21.158684593267196\n",
-      "2017-07-20 15:46:02,897 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:02,898 - INFO - Adjusting motor MIRR:TST:test_m1h to position 1256.4861192121707\n",
-      "2017-07-20 15:46:03,011 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 209.25453132668488\n",
-      "2017-07-20 15:46:03,012 - INFO - Succesfully walked to value 209.25453132668488 (target=210) after 3 steps.\n",
-      "2017-07-20 15:46:03,013 - INFO - Found equation of (-2.214754070224962, 2992.4321565111486) between linear fit of MIRR:TST:test_m1h to TST:test_p3h\n",
-      "2017-07-20 15:46:03,234 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at -57210.2684784569\n",
-      "2017-07-20 15:46:03,235 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:03,236 - INFO - Walking motor, error after step #0 -> 57480.2684784569\n",
-      "2017-07-20 15:46:03,237 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:03,352 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at -56752.50884796505\n",
-      "2017-07-20 15:46:03,353 - INFO - Walking motor, error after step #1 -> 57022.50884796505\n",
-      "2017-07-20 15:46:03,354 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:03,355 - INFO - Adjusting motor MIRR:TST:test_m2h to position 1255.68811087712\n",
-      "2017-07-20 15:46:03,471 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 557.7155008460301\n",
-      "2017-07-20 15:46:03,472 - INFO - Walking motor, error after step #2 -> -287.71550084603007\n",
-      "2017-07-20 15:46:03,473 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:03,474 - INFO - Adjusting motor MIRR:TST:test_m2h to position 1249.4344414263348\n",
-      "2017-07-20 15:46:03,588 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 270.8871830680273\n",
-      "2017-07-20 15:46:03,590 - INFO - Succesfully walked to value 270.8871830680273 (target=270.0) after 3 steps.\n",
-      "2017-07-20 15:46:03,590 - INFO - Found equation of (46.00635180937579, -57211.47911131522) between linear fit of MIRR:TST:test_m2h to TST:test_dg3\n",
-      "2017-07-20 15:46:03,822 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 593.1904542619974\n",
-      "2017-07-20 15:46:03,823 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:03,824 - INFO - Walking motor, error after step #0 -> -383.1904542619974\n",
-      "2017-07-20 15:46:03,825 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:03,826 - INFO - Using gradient of -2.214754070224962 for naive step...\n",
-      "2017-07-20 15:46:03,846 - INFO - ['TST:test_p3h_detector_stats2_centroid_x', 'MIRR:TST:test_m1h_pitch']\n",
-      "2017-07-20 15:46:03,847 - INFO - {'TST:test_p3h_detector_stats2_centroid_x': 594.45368400973302, 'MIRR:TST:test_m1h_pitch': 1256.4861192121707}\n",
-      "2017-07-20 15:46:03,964 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 207.5383879749233\n",
-      "2017-07-20 15:46:03,965 - INFO - Walking motor, error after step #1 -> 2.461612025076704\n",
-      "2017-07-20 15:46:03,966 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:03,967 - INFO - Adjusting motor MIRR:TST:test_m1h to position 1428.9674732811611\n",
-      "2017-07-20 15:46:04,088 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 210.73017411190023\n",
-      "2017-07-20 15:46:04,089 - INFO - Succesfully walked to value 210.73017411190023 (target=210) after 2 steps.\n",
-      "2017-07-20 15:46:04,090 - INFO - Found equation of (-2.2231997376188866, 3387.2428920483103) between linear fit of MIRR:TST:test_m1h to TST:test_p3h\n",
-      "2017-07-20 15:46:04,336 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at -7995.113015803845\n",
-      "2017-07-20 15:46:04,337 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:04,338 - INFO - Walking motor, error after step #0 -> 8265.113015803847\n",
-      "2017-07-20 15:46:04,339 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:04,340 - INFO - Using gradient of 46.00635180937579 for naive step...\n",
-      "2017-07-20 15:46:04,362 - INFO - ['TST:test_dg3_detector_stats2_centroid_x', 'MIRR:TST:test_m2h_pitch']\n",
-      "2017-07-20 15:46:04,363 - INFO - {'TST:test_dg3_detector_stats2_centroid_x': -7996.5008068374946, 'MIRR:TST:test_m2h_pitch': 1249.4344414263348}\n",
-      "2017-07-20 15:46:04,489 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 273.0560193141365\n",
-      "2017-07-20 15:46:04,490 - INFO - Walking motor, error after step #1 -> -3.0560193141355967\n",
-      "2017-07-20 15:46:04,491 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:04,492 - INFO - Adjusting motor MIRR:TST:test_m2h to position 1429.049762692403\n",
-      "2017-07-20 15:46:04,614 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 267.9541042195013\n",
-      "2017-07-20 15:46:04,615 - INFO - Walking motor, error after step #2 -> 2.0458957804996203\n",
-      "2017-07-20 15:46:04,617 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:04,618 - INFO - Adjusting motor MIRR:TST:test_m2h to position 1429.0719858020007\n",
-      "2017-07-20 15:46:04,744 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 269.7150415942525\n",
-      "2017-07-20 15:46:04,745 - INFO - Succesfully walked to value 269.7150415942525 (target=270.0000000000009) after 3 steps.\n",
-      "2017-07-20 15:46:04,746 - INFO - Found equation of (46.01327721670974, -65486.380423690935) between linear fit of MIRR:TST:test_m2h to TST:test_dg3\n",
-      "2017-07-20 15:46:04,988 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 262.46773152297027\n",
-      "2017-07-20 15:46:04,989 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:04,990 - INFO - Walking motor, error after step #0 -> -52.46773152297027\n",
-      "2017-07-20 15:46:04,991 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:04,992 - INFO - Using gradient of -2.2231997376188866 for naive step...\n",
-      "2017-07-20 15:46:05,070 - INFO - ['TST:test_p3h_detector_stats2_centroid_x', 'MIRR:TST:test_m1h_pitch']\n",
-      "2017-07-20 15:46:05,071 - INFO - {'TST:test_p3h_detector_stats2_centroid_x': 265.10380530750854, 'MIRR:TST:test_m1h_pitch': 1428.9674732811611}\n",
-      "2017-07-20 15:46:05,197 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 211.1253785677299\n",
-      "2017-07-20 15:46:05,198 - INFO - Succesfully walked to value 211.1253785677299 (target=210) after 1 steps.\n",
-      "2017-07-20 15:46:05,199 - INFO - Found equation of (-2.124618512978424, 3299.796516592396) between linear fit of MIRR:TST:test_m1h to TST:test_p3h\n",
-      "2017-07-20 15:46:05,470 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at -917.5972021739992\n",
-      "2017-07-20 15:46:05,472 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:05,474 - INFO - Walking motor, error after step #0 -> 1187.597202173999\n",
-      "2017-07-20 15:46:05,474 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:05,475 - INFO - Using gradient of 46.01327721670974 for naive step...\n",
-      "2017-07-20 15:46:05,514 - INFO - ['TST:test_dg3_detector_stats2_centroid_x', 'MIRR:TST:test_m2h_pitch']\n",
-      "2017-07-20 15:46:05,515 - INFO - {'TST:test_dg3_detector_stats2_centroid_x': -916.41591368831973, 'MIRR:TST:test_m2h_pitch': 1429.0719858020007}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2017-07-20 15:46:05,653 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 266.927665334671\n",
-      "2017-07-20 15:46:05,654 - INFO - Walking motor, error after step #1 -> 3.0723346653288672\n",
-      "2017-07-20 15:46:05,655 - INFO - Using model Model(linear) to determine next step.\n",
-      "2017-07-20 15:46:05,656 - INFO - Adjusting motor MIRR:TST:test_m2h to position 1454.9231044430674\n",
-      "2017-07-20 15:46:05,796 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 270.8546504498207\n",
-      "2017-07-20 15:46:05,797 - INFO - Succesfully walked to value 270.8546504498207 (target=269.9999999999999) after 2 steps.\n",
-      "2017-07-20 15:46:05,798 - INFO - Found equation of (45.93362325190344, -66559.46130659437) between linear fit of MIRR:TST:test_m2h to TST:test_dg3\n",
-      "2017-07-20 15:46:06,081 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 217.5075631044156\n",
-      "2017-07-20 15:46:06,082 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:06,083 - INFO - Walking motor, error after step #0 -> -7.5075631044155955\n",
-      "2017-07-20 15:46:06,084 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:06,088 - INFO - Using gradient of -2.124618512978424 for naive step...\n",
-      "2017-07-20 15:46:06,135 - INFO - ['TST:test_p3h_detector_stats2_centroid_x', 'MIRR:TST:test_m1h_pitch']\n",
-      "2017-07-20 15:46:06,139 - INFO - {'TST:test_p3h_detector_stats2_centroid_x': 218.52685462692915, 'MIRR:TST:test_m1h_pitch': 1453.7532828398321}\n",
-      "2017-07-20 15:46:06,287 - INFO - Averaged data yielded TST:test_p3h_detector_stats2_centroid_x is at 208.55912994567362\n",
-      "2017-07-20 15:46:06,288 - INFO - Succesfully walked to value 208.55912994567362 (target=210) after 1 steps.\n",
-      "2017-07-20 15:46:06,289 - INFO - Found equation of (-2.3566497201899086, 3644.0044760953247) between linear fit of MIRR:TST:test_m1h to TST:test_p3h\n",
-      "2017-07-20 15:46:06,555 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 77.12057221727919\n",
-      "2017-07-20 15:46:06,556 - INFO - Unable to yield estimate from model Model(linear)\n",
-      "2017-07-20 15:46:06,557 - INFO - Walking motor, error after step #0 -> 192.87942778272082\n",
-      "2017-07-20 15:46:06,558 - INFO - No model yielded accurate prediction, using naive plan\n",
-      "2017-07-20 15:46:06,558 - INFO - Using gradient of 45.93362325190344 for naive step...\n",
-      "2017-07-20 15:46:06,599 - INFO - ['TST:test_dg3_detector_stats2_centroid_x', 'MIRR:TST:test_m2h_pitch']\n",
-      "2017-07-20 15:46:06,600 - INFO - {'TST:test_dg3_detector_stats2_centroid_x': 79.452746399826466, 'MIRR:TST:test_m2h_pitch': 1454.9231044430674}\n",
-      "2017-07-20 15:46:06,734 - INFO - Averaged data yielded TST:test_dg3_detector_stats2_centroid_x is at 270.7572695128481\n",
-      "2017-07-20 15:46:06,735 - INFO - Succesfully walked to value 270.7572695128481 (target=270.0) after 1 steps.\n",
-      "2017-07-20 15:46:06,736 - INFO - Found equation of (46.39727064625333, -67426.17438702355) between linear fit of MIRR:TST:test_m2h to TST:test_dg3\n",
-      "2017-07-20 15:46:06,978 - INFO - Finished in 4.54s after 8 mirror walks, 9 yag cycles, and 0 recoveries\n",
-      "2017-07-20 15:46:06,979 - INFO - Aligned to [210.63840721342152, 270.7572695128481]\n",
-      "2017-07-20 15:46:06,980 - INFO - Goals were [210, 270]\n",
-      "2017-07-20 15:46:06,981 - INFO - Deltas are [0.63840721342151596, 0.75726951284809729]\n"
+      "2017-07-26 12:59:29,106 - INFO - pswalker.plans - Averaged data yielded TST:test_mecy1_detector_stats2_centroid_x is at 2993.1685147691433\n",
+      "2017-07-26 12:59:29,108 - INFO - pswalker.callbacks - Unable to yield estimate from model Model(linear)\n",
+      "2017-07-26 12:59:29,109 - INFO - pswalker.plans - Walking motor, error after step #0 -> -2723.1685147691433\n",
+      "2017-07-26 12:59:29,110 - INFO - pswalker.plans - No model yielded accurate prediction, using naive plan\n",
+      "2017-07-26 12:59:29,244 - INFO - pswalker.plans - Averaged data yielded TST:test_mecy1_detector_stats2_centroid_x is at 3244.887042483765\n",
+      "2017-07-26 12:59:29,246 - INFO - pswalker.plans - Walking motor, error after step #1 -> -2974.887042483765\n",
+      "2017-07-26 12:59:29,247 - INFO - pswalker.plans - Using model Model(linear) to determine next step.\n",
+      "2017-07-26 12:59:29,249 - INFO - pswalker.plans - Adjusting motor MIRR:TST:test_xrtm2 to position -108.18167811876502\n",
+      "2017-07-26 12:59:29,361 - INFO - pswalker.plans - Averaged data yielded TST:test_mecy1_detector_stats2_centroid_x is at 259.0147569618959\n",
+      "2017-07-26 12:59:29,362 - INFO - pswalker.plans - Walking motor, error after step #2 -> 10.985243038104102\n",
+      "2017-07-26 12:59:29,364 - INFO - pswalker.plans - Using model Model(linear) to determine next step.\n",
+      "2017-07-26 12:59:29,365 - INFO - pswalker.plans - Adjusting motor MIRR:TST:test_xrtm2 to position -107.74862180660499\n",
+      "2017-07-26 12:59:29,477 - INFO - pswalker.plans - Averaged data yielded TST:test_mecy1_detector_stats2_centroid_x is at 270.24673771748786\n",
+      "2017-07-26 12:59:29,478 - INFO - pswalker.plans - Succesfully walked to value 270.24673771748786 (target=270) after 3 steps.\n",
+      "2017-07-26 12:59:29,480 - INFO - pswalker.iterwalk - Found equation of (25.26726149482299, 2992.6352603804394) between linear fit of MIRR:TST:test_xrtm2 to TST:test_mecy1\n",
+      "2017-07-26 12:59:29,481 - INFO - pswalker.iterwalk - Finished in 0.49s after 1 mirror walks, 1 yag cycles, and 0 recoveries\n",
+      "2017-07-26 12:59:29,483 - INFO - pswalker.iterwalk - Aligned to [270.24673771748786]\n",
+      "2017-07-26 12:59:29,484 - INFO - pswalker.iterwalk - Goals were [270]\n",
+      "2017-07-26 12:59:29,485 - INFO - pswalker.iterwalk - Deltas are [0.24673771748786066]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['8d48437c-766e-44b7-8f09-fa63915f3e9b']"
+       "['cede5e6d-a5a3-4de7-9c5a-8d03464ef83c']"
       ]
      },
      "execution_count": 6,
@@ -303,7 +229,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "507\n"
+      "47\n"
      ]
     }
    ],
@@ -339,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/run_skywalker.ipynb
+++ b/notebooks/run_skywalker.ipynb
@@ -148,14 +148,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#Create Skywalker plan\n",
     "yags = alignment_yags[ALIGNMENT]\n",
     "mots = alignment_mots[ALIGNMENT]\n",
     "goals = alignment_goals[ALIGNMENT]\n",
-    "det_rbv = 'detector_stats2_centroid_x'\n",
+    "if SIMULATION:\n",
+    "    det_rbv = 'detector_stats2_centroid_x'\n",
+    "else:\n",
+    "    det_rbv = 'detector_stats2_centroid_y'\n",
     "mot_rbv = 'pitch'\n",
     "plan = skywalker(yags, mots, det_rbv, mot_rbv,\n",
     "        goals, first_steps=first_steps, tolerances=tolerances,\n",
@@ -165,7 +170,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#Create RunEngine\n",

--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -102,6 +102,7 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
     num = len(detectors)
 
     # Listify most optional arguments
+    goals = as_list(goals, num)
     starts = as_list(starts, num)
     first_steps = as_list(first_steps, num, float)
     gradients = as_list(gradients, num)

--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -123,6 +123,9 @@ dg3_name = "dg3"
 mfxdg1 = "MFX:DG1:PIM"
 mfxdg1_det = "MFX:DG1:P6740"
 mfxdg1_name = "mfxdg1"
+mecy1 = "MEC:PIM1"
+mecy1_det = "MEC:HXM:CVV:01"
+mecy1_name = "mecy1"
 pitch_key = "pitch"
 cent_x_key = "detector_stats2_centroid_y"
 fmt = "{}_{}"
@@ -169,6 +172,7 @@ def homs_system():
     system['hx2'] = PIM(hx2, name=hx2_name)
     system['dg3'] = PIM(dg3, name=dg3_name)
     system['mfxdg1'] = PIM(mfxdg1, det_pv=mfxdg1_det, name=mfxdg1_name)
+    system['mecy1'] = PIM(mecy1, det_pv=mecy1_det, name=mecy1_name)
     system['y1'] = system['hx2']
     system['y2'] = system['dg3']
     return system


### PR DESCRIPTION
Added mecy1 to the skywalker system and reworked the ipython notebook to let us align to different targets. I didn't flesh out the specifics for the xcs alignment but that can wait. I chose to run a 1-yag 1-motor skywalker rather than a walk_to_pixel because the walk_to_pixel fitting routines were throwing exceptions when done on their own, and then I figured we might like to have some of the higher-level recovery stuff we implemented in skywalker.