### PR TITLE
ENH: Clean up lcls_RE

### DIFF
--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -48,21 +48,6 @@ def lcls_RE(alarming_pvs=None, RE=None):
     return RE
 
 
-def homs_RE():
-    """
-    Instantiate an lcls_RE with the correct alarming pvs and a suspender for
-    lightpath blockage.
-
-    Returns
-    -------
-    RE: RunEngine
-    """
-    RE = lcls_RE()
-    # TODO determine what the correct alarm pvs even are
-    # TODO include lightpath suspender
-    return RE
-
-
 def skywalker(detectors, motors, det_fields, mot_fields, goals,
               first_steps=1,
               gradients=None, tolerances=20, averages=20, timeout=600,

--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -77,10 +77,4 @@ def skywalker(detectors, motors, det_fields, mot_fields, goals,
                         filters=filters)
         return (yield from walk)
 
-
     return (yield from letsgo())
-
-def get_lightpath_suspender(yags):
-    # TODO initialize lightpath
-    # Make the suspender to go to the last yag and exclude prev yags
-    return LightpathSuspender(yags[-1], exclude=yags[:-1])

--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -4,14 +4,9 @@ import logging
 
 from bluesky import RunEngine
 from bluesky.plans import run_decorator
-from bluesky.callbacks import LiveTable
-from pcdsdevices.epics.pim import PIM
-from pcdsdevices.epics.mirror import OffsetMirror
 
-from .plan_stubs import prep_img_motors
 from .recovery import homs_recovery, sim_recovery
-from .suspenders import (BeamEnergySuspendFloor, BeamRateSuspendFloor,
-                         PvAlarmSuspend, LightpathSuspender)
+from .suspenders import BeamEnergySuspendFloor, BeamRateSuspendFloor
 from .iterwalk import iterwalk
 from .utils.argutils import as_list
 from .utils import field_prepend

--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -19,17 +19,12 @@ from .utils import field_prepend
 logger = logging.getLogger(__name__)
 
 
-def lcls_RE(alarming_pvs=None, RE=None):
+def lcls_RE(RE=None):
     """
-    Instantiate a run engine that pauses when the lcls beam has problems, and
-    optionally when various PVs enter a MAJOR alarm state.
+    Instantiate a run engine that pauses when the lcls beam has problems.
 
     Parameters
     ----------
-    alarming_pvs: list of str, optional
-        If provided, we'll suspend the run engine when any of these PVs report
-        a MAJOR alarm state.
-
     RE: RunEngine, optional
         If provided, we'll add suspenders to and return the provided RunEngine
         instead of creating a new one.
@@ -39,12 +34,8 @@ def lcls_RE(alarming_pvs=None, RE=None):
     RE: RunEngine
     """
     RE = RE or RunEngine({})
-    RE.install_suspender(BeamEnergySuspendFloor(0.01))
-    RE.install_suspender(BeamRateSuspendFloor(2))
-    alarming_pvs = alarming_pvs or []
-    for pv in alarming_pvs:
-        RE.install_suspender(PvAlarmSuspend(pv, "MAJOR"))
-    RE.msg_hook = RE.log.debug
+    RE.install_suspender(BeamEnergySuspendFloor(1, sleep=5, averages=100))
+    RE.install_suspender(BeamRateSuspendFloor(1, sleep=5))
     return RE
 
 


### PR DESCRIPTION
Clean up the various run engine macros in skywalker.py. The intention is to use the lcls_RE macro in the jupyter notebook to set up a run engine with the beam energy and beam rate suspenders.