### PR TITLE
ENH: Pass all iterwalk arguments into recovery_plan

### DIFF
--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -103,12 +103,13 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
     recovery_plan: plan, optional
         A backup plan to run when no there is no readback on the detectors.
         This plan should expect a complete description of the situation in the
-        form of the following keyword arguments:
-            detectors: a list of all detectors
-            motors: a list of all motors
-            goals: a list of all goals
-            detector_fields: a list of the fields that correspond to the goals
-            index: which index in these equal-length lists is active
+        form of all arguments given to iterwalk, except for recovery_plan. Note
+        that these arguments are listified before being passed to
+        recovery_plan. It will also be passed 'index', which is the index in
+        all of the list arguments that is currently active.
+        Also note that there is no requirement to use all of the provided
+        arguments. A good practice is to have recovery_plan accept and ignore
+        **kwargs while explicitly including desired keywords to use.
 
     filters: list of dictionaries
         Each entry in this list should be a valid input to the filters argument
@@ -278,7 +279,18 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
 
                 ok = yield from recovery_plan(detectors=detectors,
                                               motors=motors, goals=goals,
+                                              starts=starts,
+                                              first_steps=first_steps,
+                                              gradients=gradients,
                                               detector_fields=detector_fields,
+                                              motor_fields=motor_fields,
+                                              tolerances=tolerances,
+                                              system=system,
+                                              averages=averages,
+                                              overshoot=overshoot,
+                                              max_walks=max_walks,
+                                              timeout=timeout,
+                                              filters=filters,
                                               index=index)
 
                 # Reset the finished tag because we moved something

--- a/pswalker/recovery.py
+++ b/pswalker/recovery.py
@@ -105,7 +105,7 @@ def recover_threshold(signal, threshold, motor, dir_initial, timeout=None,
 
 
 def homs_recovery(*, detectors, motors, goals, detector_fields, index,
-                  sim=False):
+                  sim=False, **kwargs):
     """
     Plan to recover the homs system should something go wrong. Is passed
     arguments as defined in iterwalk.
@@ -141,8 +141,8 @@ def homs_recovery(*, detectors, motors, goals, detector_fields, index,
     return ok
 
 
-def sim_recovery(*, detectors, motors, goals, detector_fields, index):
+def sim_recovery(*, detectors, motors, goals, detector_fields, index, **kwargs):
     return (yield from homs_recovery(detectors=detectors, motors=motors,
                                      goals=goals,
                                      detector_fields=detector_fields,
-                                     index=index, sim=True))
+                                     index=index, sim=True, **kwargs))


### PR DESCRIPTION
Let recovery_plan decide what information it does and does not need to do it's job. I doubt any plan will use all of these but this makes the documentation easier and allows us some flexibility with recovery plans.