### PR TITLE
ENH: Quick pre-run additions/fixes

### DIFF
--- a/pswalker/recovery.py
+++ b/pswalker/recovery.py
@@ -122,6 +122,7 @@ def homs_recovery(*, detectors, motors, goals, detector_fields, index,
         # This lets us test the plan
         sig = yag.detector.stats2.centroid.x
     else:
+        sig = yag.detector.stats2.centroid.y
         # The real mirror should try to return to nominal first
         logger.info("Try recovering to nominal first...")
         try:
@@ -133,7 +134,6 @@ def homs_recovery(*, detectors, motors, goals, detector_fields, index,
             logger.warning("No nominal position configured, skipping...")
         else:
             yield from mv(mirror, nominal)
-            sig = yag.detector.stats2.centroid.y
             if sig.value > sig_threshold:
                 logger.info("We have beam at the nominal position.")
                 return True

--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -37,7 +37,7 @@ def lcls_RE(RE=None):
 def skywalker(detectors, motors, det_fields, mot_fields, goals,
               first_steps=1,
               gradients=None, tolerances=20, averages=20, timeout=600,
-              sim=False, md=None):
+              sim=False, use_filters=True, md=None):
     """
     Iterwalk as a base, with arguments for branching
     """
@@ -54,9 +54,13 @@ def skywalker(detectors, motors, det_fields, mot_fields, goals,
     _md.update(md or {})
     goals = [480 - g for g in goals]
     det_fields = as_list(det_fields, length=len(detectors))
-    filters = []
-    for det, fld in zip(detectors, det_fields):
-        filters.append({field_prepend(fld, det): lambda x: x > 0})
+    if use_filters:
+        filters = []
+        for det, fld in zip(detectors, det_fields):
+            filters.append({field_prepend(fld, det): lambda x: x > 0})
+    else:
+        # Don't filter on sims unless testing recovery
+        filters = None
     if sim:
         recovery_plan = sim_recovery
     else:


### PR DESCRIPTION
Stage the FEE attenuator (Travis will fail until the corresponding FEE Att PR makes its way into pcds-devices)

Change the threshold for the beam drop suspender.

Quick dirty skywalker options for the test/sim modes. This is needed for running skywalker with instant-moving test devices, like in the notebook, which can't really run with a recovery plan.