### PR TITLE
MAINT: Moving beam stats code from psbeam to pswalker

### DIFF
--- a/pswalker/skywalker.py
+++ b/pswalker/skywalker.py
@@ -1,26 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-############
-# Standard #
-############
 import logging
 
-###############
-# Third Party #
-###############
 from pcdsdevices.epics.attenuator import FeeAtt
 from bluesky import RunEngine
 from bluesky.plans import run_decorator, stage_decorator
 
-##########
-# Module #
-##########
+from .recovery import homs_recovery, sim_recovery
+from .suspenders import BeamEnergySuspendFloor, BeamRateSuspendFloor
 from .iterwalk import iterwalk
 from .utils.argutils import as_list
 from .utils import field_prepend
-from .recovery import homs_recovery, sim_recovery
-from .suspenders import BeamEnergySuspendFloor, BeamRateSuspendFloor
-from .statistics import beam_statistics
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +35,10 @@ def lcls_RE(RE=None):
     return RE
 
 
-def skywalker(detectors, motors, det_fields, mot_fields, goals, first_steps=1,
+def skywalker(detectors, motors, det_fields, mot_fields, goals,
+              first_steps=1,
               gradients=None, tolerances=20, averages=20, timeout=600,
-              sim=False, use_filters=True, md=None, get_stats=True,
-              img_field="image1.array_data", sz_field="image1.array_size",
-              cent_field="stats2.centroid"):
+              sim=False, use_filters=True, md=None):
     """
     Iterwalk as a base, with arguments for branching
     """
@@ -86,10 +75,6 @@ def skywalker(detectors, motors, det_fields, mot_fields, goals, first_steps=1,
     @run_decorator(md=_md)
     @stage_decorator(to_stage)
     def letsgo():
-        if get_stats:
-            stats = yield from beam_statistics(detectors, img_field, sz_field,
-                                               cent_field, image_delay=0.1)
-
         walk = iterwalk(detectors, motors, goals, first_steps=first_steps,
                         gradients=gradients,
                         tolerances=tolerances, averages=averages, timeout=timeout,

--- a/pswalker/statistics.py
+++ b/pswalker/statistics.py
@@ -13,18 +13,45 @@ from copy import copy
 ###############
 import numpy as np
 from bluesky.plans import checkpoint
-from psbeam.utils import signal_tuple
-from psbeam.plans.characterize import characterize
+from psbeam.filters import contour_area_filter
+from psbeam.utils import (to_image, signal_tuple)
+from psbeam.beamexceptions import NoContoursDetected
+from psbeam.preprocessing import uint_resize_gauss
+from psbeam.contouring import (get_largest_contour, get_moments, get_centroid,
+                               get_contour_size, get_similarity)
 
 ##########
 # Module #
 ##########
 from .plan_stubs import prep_img_motors
-from .utils.argutils import as_list, field_prepend
 from .plans import walk_to_pixel, measure_average, measure
 from .utils.exceptions import FilterCountError
+from .utils.argutils import as_list, field_prepend
 
 logger = logging.getLogger(__name__)
+
+# List of characteristics in the return dictionary
+
+stat_list = ["sum_mn_raw",          # Mean of the sum of raw image
+             "sum_std_raw",         # Std of sum of the raw image
+             "sum_mn_prep",         # Mean of the sum of preprocessed image
+             "sum_std_prep",        # Std of sum of the preprocessed image
+             "mean_mn_raw",         # Mean of the mean of raw image
+             "mean_std_raw",        # Std of the mean of raw_image
+             "mean_mn_prep",        # Mean of the mean of preprocessed image
+             "mean_std_prep",       # Std of the mean of preprocessed image
+             "area_mn",             # Mean of area of the beam
+             "area_std",            # Std of area of the beam
+             "centroid_x_mn",       # Mean of centroid x
+             "centroid_x_std",      # Std of centroid x
+             "centroid_y_mn",       # Mean of centroid y
+             "centroid_y_std",      # Std of centroid y
+             "length_mn",           # Mean of the beam length
+             "length_std",          # Std of the beam length
+             "width_mn",            # Mean of the beam width
+             "width_std",           # Std of the beam width
+             "match_mn",            # Mean beam similarity score
+             "match_std"]           # Std beam similarity score
 
 def beam_statistics(detectors, array_field="image1.array_data",
                     size_field="image1.array_size",
@@ -288,5 +315,341 @@ def beam_statistics(detectors, array_field="image1.array_data",
                                "data. No AD statistics added for detector '{0}'"
                                "".format(detectors[idx].name))
 
-    return beam_stats
+    return beam_stats    
+
+def process_image(image, resize=1.0, kernel=(13,13), uint_mode="scale",
+                  thresh_mode="otsu", thresh_factor=3):
+    """
+    Processes the input image and returns a vector of numbers charcterizing the
+    beam.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Image to process
+
+    resize : float, optional
+        Resize the image before performing any processing.
+
+    kernel : tuple, optional
+        Size of kernel to use when running the gaussian filter.
+
+    uint_mode : str, optional
+    	Conversion mode to use when converting to uint8. For extended
+    	documentation, see preprocessing.to_uint8. Valid modes are:
+    		['clip', 'norm', 'scale']
+
+    thresh_mode : str, optional
+    	Thresholding mode to use. For extended documentation see
+    	preprocessing.threshold_image. Valid modes are:
+    		['mean', 'top', 'bottom', 'adaptive', 'otsu']
+
+    thresh_factor : int, float
+    	Factor to pass to the mean threshold.
+
+    Returns
+    -------
+    np.ndarray
+    	Array containing all the relevant fields of the image    
+    """
+    # Preprocess with a gaussian filter
+    image_prep = uint_resize_gauss(image, fx=resize, fy=resize, kernel=kernel,
+                                   mode=uint_mode)
     
+    # The main pipeline
+    try:
+        contour, area = get_largest_contour(image_prep, thesh_mode=thresh_mode,
+                                            factor=thresh_factor)
+        M = get_moments(contour=contour)
+        centroid_y, centroid_x = [pos//resize for pos in get_centroid(M)]
+        l, w = [val//resize for val in get_contour_size(contour=contour)]
+        match = get_similarity(contour)
+
+    # No beam on Image, set values to make this clear
+    except NoContoursDetected:
+        area = -1
+        centroid_y, centroid_x = [-1, -1]
+        l = -1
+        w = -1   
+        match = -1
+
+    # Basic info
+    mean_raw = image.mean()
+    mean_prep = image_prep.mean()
+    sum_raw = image.sum()
+    sum_prep = image_prep.sum()
+    
+    return np.array([sum_raw, sum_prep, mean_raw, mean_prep, area, centroid_x,
+                     centroid_y, l, w, match])
+
+def process_det_data(data, array_signal, size_signal, resize=1.0, kernel=(13,13),
+                     uint_mode="scale", thresh_mode="otsu", thresh_factor=3,
+                     md=None, **kwargs):
+    """
+    Processes each image in the inputted event docs and returns another dict
+    with the beam statistics calculated for all the events.
+
+    Parameters
+    ----------
+    data : list
+    	The list of event doc dicts that contain the array_data to be processed.
+
+    array_signal : ophyd.signal.Signal
+    	Signal that emitted the array data we will be processing.
+
+    size_signal : ophyd.signal.Signal
+    	Detector signal that returns the expected size of the array.
+
+    resize : float, optional
+        Resize the image before performing any processing.
+
+    kernel : tuple, optional
+        Size of kernel to use when running the gaussian filter.
+
+    uint_mode : str, optional
+    	Conversion mode to use when converting to uint8. For extended
+    	documentation, see preprocessing.to_uint8. Valid modes are:
+    		['clip', 'norm', 'scale']
+
+    thresh_mode : str, optional
+    	Thresholding mode to use. For extended documentation see
+    	preprocessing.threshold_image. Valid modes are:
+    		['mean', 'top', 'bottom', 'adaptive', 'otsu']
+
+    thresh_factor : int or float, optional
+    	Factor to pass to the mean threshold.
+
+    md : str, optional
+    	How much meta data to include in the output dict. Valid options are:
+    		[None, 'basic', 'all']
+    	Note: The 'all' option is for debugging purposes and should not be used
+    	in production.
+
+    Returns
+    -------
+    results_dict : dict
+    	Dictionary containing the statistics obtained from the array data, and
+    	optionally some meta-data.
+    """
+    stats_array = np.zeros((len(data), 10))
+    for i, event in enumerate(data):
+        # Array of processed image data for each shot in a dict for each det
+        stats_array[i,:] = process_image(
+            to_image(event[array_signal.name], size_signal=size_signal),
+            kernel=kernel, resize=resize, uint_mode=uint_mode,
+            thresh_mode=thresh_mode, **kwargs)
+
+    # Remove any rows that have -1 as a value
+    stats_array_dropped = np.delete(stats_array, np.unique(np.where(
+        stats_array == -1)[0]), axis=0)
+
+    # Turn the data into a mean and std for each entry                
+    results_dict = dict()
+    for i in range(stats_array_dropped.shape[1]):
+        results_dict[stat_list[2*i]] = stats_array_dropped[:,i].mean()
+        results_dict[stat_list[2*i+1]] = stats_array_dropped[:,i].std()
+
+    # Meta-Data
+    if md is None or md.lower() == "none":
+        pass    
+    # Basic meta-data
+    elif md.lower() == "basic":
+        results_dict["md"] = {
+            "len_data" : len(data),
+            "dropped" : len(data) - len(stats_array_dropped)}
+        
+    # All computed data - debugging purposes only!
+    elif md.lower() == "all":
+        logger.warning("Meta-Data is set to 'all'")
+        results_dict["md"] = {
+            "len_data" : len(data),
+            "dropped" : len(data) - len(stats_array_dropped),
+            "doc" : data,
+            "stats_array" : stats_array,
+            "dropped_array" : stats_array_dropped,
+        }
+
+    else:
+        logger.warning("Invalid meta-data mode entry '{0}'. Valid modes are "
+                       "'basic', 'all' or None. Skipping.".format(md))
+    return results_dict
+
+def characterize(detector, array_signal_str, size_signal_str, num=10,
+                 delay=None, filters=None, drop_missing=True, 
+                 filter_kernel=(9,9), resize=1.0, uint_mode="scale",
+                 min_area=100, filter_factor=(9,9), min_area_factor=3,
+                 kernel=(9,9), thresh_factor=3, thresh_mode="otsu", md=None,
+                 **kwargs):
+    """
+    Characterizes the beam profile by computing various metrics and statistics
+    of the beam using the inputted detector. The function performs 'num' reads
+    on the array_data field of the detector, optionally filtering shots until
+    'num' shots have been collected, and then runs the processing pipeline on
+    each of the resulting arrays.
+
+    The processing pipeline computes the contours of the image, from which the
+    area, length, width, centroid and circularity of the contour is computed.
+    Additionally, the sum and mean intensity values are computed of both the
+    preprocessed image and the raw image.
+
+    Once the pipeline has been finished processing for all 'num' images, the
+    mean and standard deviation of each statistic is computed, giving a total
+    20 entries to the stats dictionary.
+
+    Computed Statistics
+    -------------------
+    sum_mn_raw
+    	Mean of the sum of the raw image intensities.
+    
+    sum_std_raw
+    	Standard deviation of sum of the raw image pixel intensities.
+    
+    sum_mn_prep
+    	Mean of the sum of the preprocessed image pixel intensities. 
+    
+    sum_std_prep
+    	Standard deviation of the sum of the preprocessed image pixel
+    	intensities.
+    
+    mean_mn_raw
+    	Mean of the mean of the raw image pixel intensities.
+    
+    mean_std_raw
+    	Standard deviation of the mean of the raw image pixel intensities.
+    
+    mean_mn_prep
+    	Mean of the mean of the preprocessed image pixel intensities.
+    
+    mean_std_prep
+    	Standard deviation of the mean of the preprocessed image pixel
+    	intensities.
+    
+    area_mn
+    	Mean of the area of the contour of the beam.
+    
+    area_std
+    	Standard deviation of area of the contour of the beam.
+    
+    centroid_x_mn
+    	Mean of the contour centroid x.
+    
+    centroid_x_std
+    	Standard deviation of the contour centroid x.
+    
+    centroid_y_mn
+    	Mean of the contour centroid y.
+    
+    centroid_y_std
+    	Standard deviation of the contour centroid y.
+    
+    length_mn
+    	Mean of the contour length.
+    
+    length_std
+    	Standard deviation of the contour length.
+    
+    width_mn
+    	Mean of the contour width.
+    
+    width_std
+    	Standard deviation of the contour width.
+    
+    match_mn
+    	Mean score of contour similarity to a binary image of a circle.
+    
+    match_std
+    	Standard deviation of score of contour similarity to a binary image of
+    	a circle.
+
+    Parameters
+    ----------
+    detector : detector obj
+    	Detector object that contains the components for the array data and
+    	image shape data.
+
+    array_signal_str : str
+    	The string name of the array_data signal.
+
+    size_signal_str : str
+    	The string name of the signal that will provide the shape of the image.
+    
+    num : int
+        Number of measurements that need to pass the filters.
+
+    delay : float
+        Minimum time between consecutive reads of the detectors.
+
+    filters : dict, optional
+        Key, callable pairs of event keys and single input functions that
+        evaluate to True or False. 
+
+    drop_missing : bool, optional
+        Choice to include events where event keys are missing.
+
+    filter_kernel : tuple, optional
+    	Kernel to use when gaussian blurring in the contour filter.
+
+    resize : float, optional
+    	How much to resize the image by before doing any calculations.
+
+    uint_mode : str, optional
+    	Conversion mode to use when converting to uint8.
+
+    min_area : float, optional
+    	Minimum area of the otsu thresholded beam.
+
+    filter_factor : float
+    	Factor to pass to the filter mean threshold.
+
+    min_area_factor : float
+    	The amount to scale down the area for comparison with the mean threshold
+    	contour area.
+    
+    kernel : tuple, optional
+        Size of kernel to use when running the gaussian filter.    
+
+    thresh_mode : str, optional
+    	Thresholding mode to use. For extended documentation see
+    	preprocessing.threshold_image. Valid modes are:
+    		['mean', 'top', 'bottom', 'adaptive', 'otsu']
+
+    thresh_factor : int or float, optional
+    	Factor to pass to the mean threshold.
+
+    md : str, optional
+    	How much meta data to include in the output dict. Valid options are:
+    		[None, 'basic', 'all']
+    	Note: The 'all' option is for debugging purposes and should not be used
+    	in production.
+
+    Returns
+    -------
+    results_dict : dict
+    	Dictionary containing the statistics obtained from the array data, and
+    	optionally some meta-data.    
+    """   
+    # Get the image and size signals
+    array_signal = getattr(detector, array_signal_str)
+    size_signal = getattr(detector, size_signal_str)
+    
+    # Apply the default filter
+    if filters is None:
+        filters = dict()
+    array_signal_str_full = detector.name + "_" + array_signal_str.replace(
+        ".", "_")
+    filters[array_signal_str_full] = lambda image : contour_area_filter(
+        to_image(image, detector, size_signal), kernel=filter_kernel,
+        min_area=min_area, min_area_factor=min_area_factor,
+        factor=filter_factor, uint_mode=uint_mode)
+    
+    # Get images for all the shots
+    data = yield from measure([array_signal], num=num, delay=delay,
+                              filters=filters, drop_missing=drop_missing)
+    
+    # Process the data    
+    results = process_det_data(data, array_signal, size_signal, kernel=kernel,
+                               uint_mode=uint_mode, thresh_mode=thresh_mode,
+                               thresh_factor=thresh_factor, resize=resize,
+                               md=md, **kwargs)
+                                    
+    return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,15 @@ def slow_lcls_two_bounce_system():
                           timestamp=time.time())
         return update_pixel
 
+    # Patch with image
+    yield_image_hx2 = yield_seq_beam_image(images_hx2, idx=0)
+    y1.detector.image1._image = lambda : _next_image(
+        y1.detector.image1.array_counter, yield_image_hx2)
+
+    yield_image_dg3 = yield_seq_beam_image(images_dg3, idx=0)
+    y2.detector.image1._image = lambda : _next_image(
+        y2.detector.image1.array_counter, yield_image_dg3)
+
     m1.subscribe(make_update_pixel(y1), m1.SUB_READBACK)
     m2.subscribe(make_update_pixel(y2), m2.SUB_READBACK)
 

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -23,7 +23,7 @@ from pcdsdevices.sim.pim import PIM
 from math import nan, isnan
 
 logger = logging.getLogger(__name__)
-tmo = 10
+tmo = 15
 
 
 def test_prep_img_motors(RE, fake_yags):

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -10,7 +10,7 @@ from ophyd.device import Staged
 from pswalker.recovery import recover_threshold
 
 logger = logging.getLogger(__name__)
-tmo = 10
+tmo = 15
 
 
 @pytest.mark.timeout(tmo)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -9,13 +9,175 @@ import logging
 import pytest
 import numpy as np
 from bluesky.plans import run_wrapper
+from psbeam.beamdetector import detect
+from psbeam.beamexceptions import (NoBeamDetected, NoContoursDetected)
+from psbeam.filters import contour_area_filter
+from psbeam.preprocessing import uint_resize_gauss
+from psbeam.contouring import (get_largest_contour, get_moments, get_centroid,
+                               get_contour_size, get_similarity)
 
 ##########
 # Module #
 ##########
+from .utils import collector
+from .conftest import beam_images
 from pswalker.statistics import beam_statistics
+from pswalker.statistics import (process_image, process_det_data,
+                                 characterize)
+from pswalker.plans import measure
 
 logger = logging.getLogger(__name__)
+
+
+def test_sim_det_device_interfaces_with_psbeam_properly(sim_det_01):
+    det = sim_det_01
+    im_filter = lambda image : contour_area_filter(image, uint_mode="clip")
+    for i in range(10):
+        try:
+            image = det.image.image
+            idx = det.image.array_counter.value % 4
+            cent, bbox = detect(image, uint_mode="clip", filters=im_filter)
+            assert(idx != 3 or i == 0)
+        except NoBeamDetected:
+            assert(idx == 0)
+        
+def test_sim_det_interfaces_with_bluesky_correctly(sim_det_01, sim_det_02, RE):
+    global_data = None
+    det_01 = sim_det_01
+    det_02 = sim_det_02
+    im_filter = lambda image : contour_area_filter(image, uint_mode="clip")
+
+    # Fake event storage
+    array_data = []
+    array_count = []
+    col_images = collector(det_01.image.array_data.name, array_data)
+    col_count = collector(det_01.image.array_counter.name, array_count)
+
+    # A test plan that just reads the data 10 times
+    def test_plan(det):
+        read_data = yield from measure([det], num=10)
+        
+    # Include the counter in the read
+    det_01.image.read_attrs = ["array_data", "array_counter"]
+
+    # Run the plan
+    RE(run_wrapper(test_plan(det_01)), subs={'event':[col_count, col_images]})
+
+    # Check the each image against the count
+    im_filter = lambda image : contour_area_filter(image, uint_mode="clip")
+    for count, array in zip(array_count, array_data):
+        try:                
+            array_size = [int(val) for val in det_01.image.array_size.get()]
+            if array_size == [0, 0, 0]:
+                raise RuntimeError('Invalid image')
+            if array_size[-1] == 0:
+                array_size = array_size[:-1]
+
+            image = np.array(array).reshape(array_size)
+            idx = count - 1
+            cent, bbox = detect(image, uint_mode="clip", filters=im_filter)
+            assert(idx % 4 != 3 or idx == 0)
+        except NoBeamDetected:
+            assert(idx % 4 == 3)
+    
+def test_process_image_returns_correct_arrays():
+    resize = 1.0
+    kernel = (3,3)
+    uint_mode = "clip"
+    thresh_mode = "otsu"
+    thresh_factor = 3
+    
+    for image in beam_images:
+        process_array = process_image(image, kernel=kernel, uint_mode=uint_mode,
+                                      thresh_mode=thresh_mode, resize=resize,
+                                      thresh_factor=thresh_factor)
+        # Check the shape is as expected
+        assert(process_array.shape == (10,))
+
+        # Perform the same process
+        try:
+            image_prep = uint_resize_gauss(image, fx=resize, fy=resize,
+                                           kernel=kernel)
+            contour, area = get_largest_contour(
+                image_prep, factor=thresh_factor, thesh_mode=thresh_mode)
+            M = get_moments(contour=contour)
+            centroid_y, centroid_x = [pos//resize for pos in get_centroid(M)]
+            l, w = [val//resize for val in get_contour_size(contour=contour)]
+            match = get_similarity(contour)
+            
+        except NoContoursDetected:
+            area = -1
+            centroid_y, centroid_x = [-1, -1]
+            l = -1
+            w = -1   
+            match = -1
+        mean_raw = image.mean()
+        mean_prep = image_prep.mean()
+        sum_raw = image.sum()
+        sum_prep = image_prep.sum()
+        
+        # Put it all together
+        test_array = np.array([mean_raw, mean_prep, sum_raw, sum_prep, area,
+                               centroid_x, centroid_y, l, w, match])
+        assert(process_array.all() == test_array.all())
+        
+def test_process_det_data_returns_correct_detector_dict(sim_det_01, RE):
+    resize = 1.0
+    kernel = (9,9)
+    uint_mode = "clip"
+    thresh_mode = "otsu"
+    thresh_factor = 3        
+    det_01 = sim_det_01
+
+    # Fake event storage
+    array_data = []
+    array_count = []
+    col_images = collector(det_01.image.array_data.name, array_data)
+    col_count = collector(det_01.image.array_counter.name, array_count)    
+
+    # A test plan that reads the data 10 times and process the data
+    def test_plan(det):
+        read_data = yield from measure([det], num=10)
+        array_signal = det.image.array_data 
+        size_signal = det.image.array_size
+        
+        proc_dict = process_det_data(read_data, array_signal, size_signal,
+                                     kernel=kernel, resize=resize,
+                                     uint_mode=uint_mode,
+                                     thresh_mode=thresh_mode)
+        assert(len(proc_dict) == 20)
+        
+    # Run the plan
+    RE(run_wrapper(test_plan(det_01)),
+       subs={'event':[col_count, col_images]})
+
+def test_characterize_returns_correct_detector_dict(sim_det_01, RE):
+    resize = 1.0
+    kernel = (9,9)
+    uint_mode = "scale"
+    thresh_mode = "otsu"
+    thresh_factor = 3
+    min_area = 100
+    det_01 = sim_det_01
+    array_str = "image.array_data"
+    size_str = "image.array_size"
+
+    # Fake event storage
+    array_data = []
+    array_count = []
+    col_images = collector(det_01.image.array_data.name, array_data)
+    col_count = collector(det_01.image.array_counter.name, array_count)    
+
+    # A test plan that reads the data 10 times and process the data
+    def test_plan(det, sig, size):
+        proc_dict = yield from characterize(
+            det, array_str, size_str, num=10, kernel=kernel, resize=resize,
+            uint_mode=uint_mode, min_area=min_area, thresh_factor=thresh_factor)
+        assert(len(proc_dict) == 20)
+        
+    # Run the plan
+    RE(run_wrapper(test_plan(det_01, "image.array_data", "image.array_size")),
+       subs={'event':[col_count, col_images]})
 
 @pytest.mark.parametrize("resize", [1.0])
 @pytest.mark.parametrize("kernel", [(9,9)])


### PR DESCRIPTION
To remove psbeam's dependency on pswalker, I'm moving the beam stats functions into the `statistics.py` file. The functions do the following:

`process _image`
- Runs the image processing pipline on a single image and returns the results as an array.

`process_det_data`
- Loops through the read-data and applies `process_image` to each image, then compiles the data for all images into a large array to compute the mean and std of the values. It returns a dictionary mapping for each detector's beam statistics.

`characterize`
- Sets up the filters, runs `measure` to get the data, then passes it to `process_det_data`. It then returns the statistics dictionary.

Unrelated these changes, I had to increase the `tmo` parameter to 15s in `test_recovery.py` and `test_plan_stubs.py` because the runtime for some of the tests was slightly longer than 10 secs (roughly 12-13).