### PR TITLE
ENH: Clean up logging a bit prior to live demo

### DIFF
--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -210,7 +210,7 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
 
                 if abs(pos - goals[index]) < tolerances[index]:
                     logger.info("Beam was aligned on %s without a move",
-                                 detectors[index])
+                                 detectors[index].name)
                     finished[index] = True
                     done_pos[index] = pos
                     if all(finished):
@@ -247,7 +247,7 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
                              ''.format(pos, goal, detectors[index].name,
                                        motors[index].name)))
                 
-                logger.info("selected tolerance: {}".format(
+                logger.debug("selected tolerance: {}".format(
                     selected_tol[index]))
 
                 pos, models[index] = (
@@ -370,11 +370,18 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
         if max_walks is not None and n_steps > max_walks:
             logger.info("Iterwalk has reached the max_walks limit")
             break
-    logger.info(("Finished in %.2fs after %s mirror walks, %s yag cycles, "
-                 "and %s recoveries"),
-                 time.time() - start_time, mirror_walks, yag_cycles,
-                 recoveries)
-    logger.info("Aligned to %s", done_pos)
-    logger.info("Goals were %s", goals)
-    logger.info("Deltas are %s", [d - g for g, d in zip(goals, done_pos)])
-    logger.info("Mirror positions are %s", [m.position for m in motors])
+    txt = 'Finished in %.2fs after %s mirror walks, %s yag cycles, and %s '
+    txt += 'recoveries.\n'
+    txt += 'Aligned to %s\n'
+    txt += 'Goals were %s\n'
+    txt += 'Deltas are %s\n'
+    txt += 'Mirror positions are %s'
+    logger.info(txt,
+                time.time() - start_time,
+                mirror_walks,
+                yag_cycles,
+                recoveries,
+                done_pos,
+                goals,
+                [d - g for g, d in zip(goals, done_pos)],
+                [m.position for m in motors])

--- a/pswalker/plans.py
+++ b/pswalker/plans.py
@@ -227,7 +227,7 @@ def walk_to_pixel(detector, motor, target, filters=None,
     
     #Report if we did not need a model
     if not accurate_model:
-        logger.info("Reached target without use of model")
+        logger.debug("Reached target without use of model")
 
     return last_shot, accurate_model
 
@@ -493,11 +493,11 @@ def fitwalk(detectors, motor, models, target,
     while not np.isclose(last_shot, target, atol=tolerance):
         #Log error
         if not steps:
-            logger.info("Initial error before fitwalk is {}"
-                        "".format(int(target-last_shot)))
+            logger.debug("Initial error before fitwalk is {}"
+                         "".format(int(target-last_shot)))
         else:
-            logger.info("fitwalk is reporting an error {} of after step #{}"\
-                        "".format(int(target-last_shot), steps))
+            logger.debug("fitwalk is reporting an error {} of after step #{}"\
+                         "".format(int(target-last_shot), steps))
         #Break on maximum step count
         if steps >= max_steps:
             raise RuntimeError("fitwalk failed to converge after {} steps"\
@@ -506,11 +506,11 @@ def fitwalk(detectors, motor, models, target,
         #Use naive step plan if no model is accurate enough
         #or we have not made a step yet
         if not accurate_model or steps==0:
-            logger.info("No model yielded accurate prediction, "\
-                        "using naive plan")
+            logger.debug("No model yielded accurate prediction, "\
+                         "using naive plan")
             yield from naive_step()
         else:
-            logger.info("Using model {} to determine next step."\
+            logger.debug("Using model {} to determine next step."\
                         "".format(accurate_model.name))
             #Calculate estimate of next step from accurate model
             fixed_motors = dict((key, averaged_data[key])
@@ -529,7 +529,7 @@ def fitwalk(detectors, motor, models, target,
                 logger.warning(e)
 
                 #Reuse naive step
-                logger.info("Reusing naive step due to lack of accurate model")
+                logger.debug("Reusing naive step due to lack of accurate model")
                 yield from naive_step()
             else:
                 #Move system to match estimate
@@ -539,8 +539,8 @@ def fitwalk(detectors, motor, models, target,
                         raise RuntimeError("Invalid position return by fit")
                     #Attempt to move
                     try:
-                        logger.info("Adjusting motor {} to position {:.1f}"\
-                                    "".format(motor.name, pos))
+                        logger.debug("Adjusting motor {} to position {:.1f}"\
+                                     "".format(motor.name, pos))
                         yield from mv(motor, pos)
 
                     except KeyboardInterrupt as e:


### PR DESCRIPTION
- GUI taps into logger.info, so we need to be careful about logging levels.
- Multiline log messages should be in one logger.info call or else they will be displayed out of order.
- Always use object name for logger.info rather than the object