### PR TITLE
DEV: A single logger.debug line

### DIFF
--- a/pswalker/plans.py
+++ b/pswalker/plans.py
@@ -68,6 +68,7 @@ def measure_average(detectors, num=1, filters=None,
         except TypeError:
             avg[key] = data[-1][key]
 
+    logger.debug("Found the following averages: %s", avg)
     return avg
 
 


### PR DESCRIPTION
Add a single debug message for measure average's result. This is useful when we are not sure if we are interpreting the result correctly or if we've measured a bad result.