### PR TITLE
ENH: Move mirrors to nominal positions before the main iterwalk loop.

### DIFF
--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -160,8 +160,9 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
             position = mot.nominal_position
         except AttributeError:
             continue
-        yield from abs_set(mot, mot.nominal_position, group=group)
-        moving_to_nominal = True
+        if position is not None:
+            yield from abs_set(mot, mot.nominal_position, group=group)
+            moving_to_nominal = True
     if moving_to_nominal:
         yield from plan_wait(group=group)
 

--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 from copy import copy
 
-from bluesky.plans import checkpoint, mv, wait as plan_wait
+from bluesky.plans import checkpoint, mv, wait as plan_wait, abs_set
 
 from .plans import walk_to_pixel, measure_average
 from .plan_stubs import prep_img_motors
@@ -160,7 +160,7 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
             position = mot.nominal_position
         except AttributeError:
             continue
-        yield from mv(mot, mot.nominal_position, group=group)
+        yield from abs_set(mot, mot.nominal_position, group=group)
         moving_to_nominal = True
     if moving_to_nominal:
         yield from plan_wait(group=group)

--- a/pswalker/iterwalk.py
+++ b/pswalker/iterwalk.py
@@ -2,9 +2,10 @@
 # -*- coding: utf-8 -*-
 import time
 import logging
+import uuid
 from copy import copy
 
-from bluesky.plans import checkpoint, mv
+from bluesky.plans import checkpoint, mv, wait as plan_wait
 
 from .plans import walk_to_pixel, measure_average
 from .plan_stubs import prep_img_motors
@@ -151,6 +152,19 @@ def iterwalk(detectors, motors, goals, starts=None, first_steps=1,
     finished = [False] * num
     done_pos = [0] * num
     selected_tol = [None] * num
+
+    moving_to_nominal = False
+    group = str(uuid.uuid4())
+    for mot in motors:
+        try:
+            position = mot.nominal_position
+        except AttributeError:
+            continue
+        yield from mv(mot, mot.nominal_position, group=group)
+        moving_to_nominal = True
+    if moving_to_nominal:
+        yield from plan_wait(group=group)
+
     while True:
         index = 0
         while index < num:


### PR DESCRIPTION
Just the mirror changes, I am having trouble with adjusting tests in the PIM move PR for the slits so that will be separate.