### PR TITLE
FIX: max_steps should be optional in fitwalk

### DIFF
--- a/pswalker/callbacks.py
+++ b/pswalker/callbacks.py
@@ -495,44 +495,6 @@ class MultiPitchFit(LiveBuild):
                     'a1' : a1}
 
 
-class LiveModelPlot(LiveFitPlot):
-    """
-    LivePlot to display the relationship between centroid and mirror positions
-
-    Parameters
-    ----------
-    livefit : :class:`.LinearFit`
-        Fit to plot
-
-    imager : :class:`.PIM`
-        Imager centroid position
-
-    mirror : :class:`.Homs`
-        Mirror pitch
-
-    target : float, optional
-
-    num_points : int, optional
-
-    ax : Axes, optional
-    """
-    def __init__(self, livefit, imager, mirror,
-                 num_points=100, target=None, ax=None):
-        #Model information
-        self.imager = imager
-        self.mirror = mirror
-        self.target = target
-        #Initalize Plot
-        super().__init__(livefit,
-                         num_points=num_points,
-                         ax=ax)
-
-
-    def start(self, doc):
-        super().start(doc)
-        if self.target:
-            self.ax.axvline(x=self.target, color='r')
-
 class LivePlotWithGoal(LivePlot):
     """
     Build a function that updates a plot from a stream of Events.

--- a/pswalker/plans.py
+++ b/pswalker/plans.py
@@ -500,7 +500,7 @@ def fitwalk(detectors, motor, models, target,
             logger.debug("fitwalk is reporting an error {} of after step #{}"\
                          "".format(int(target-last_shot), steps))
         #Break on maximum step count
-        if steps >= max_steps:
+        if max_steps and steps >= max_steps:
             raise RuntimeError("fitwalk failed to converge after {} steps"\
                                "".format(steps))
 

--- a/pswalker/plans.py
+++ b/pswalker/plans.py
@@ -427,7 +427,9 @@ def fitwalk(detectors, motor, models, target,
         Mininum time between consecutive readings
 
     max_steps : int, optional
-        Maximum number of steps the scan will attempt before faulting
+        Maximum number of steps the scan will attempt before faulting.
+        There is a max of 10 by default, but you may disable this by setting
+        this option to None. Note that this may cause the walk to run indefinitely.
     """
     #Check all models are fitting the same key
     if len(set([model.y for model in models])) > 1:


### PR DESCRIPTION
Found this bug while making GIFs. If you had `max_steps` as `None` the comparison operator would throw an exception. Made the default behavior that the scan will try indefinitely. 

Also deprecated an old plotting class that was never completed.