### PR TITLE
BLD: Up lightpath version and allow bugfix release increments

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,11 +14,11 @@ requirements:
 
     run:
       - python {{PY_VER}}*,>=3
-      - ophyd ==1.0.0
-      - bluesky ==1.0.0
-      - pcds-devices ==0.2.0
-      - lightpath ==0.2.1
-      - psbeam ==0.0.3
+      - ophyd >=1.0.0,<1.1
+      - bluesky >=1.0.0,<1.1
+      - pcds-devices >=0.2.0,<0.3
+      - lightpath >=0.2.2,<0.3
+      - psbeam >=0.0.3,<0.1
       - simplejson
       - lmfit
       - numpy


### PR DESCRIPTION
This allows us to specify specific needed bugfix versions of these dependencies in `skywalker` without needing to go back to this package to revise the recipe and re-release, if the contents of this package don't really care about the changes.

This was a problem today because the previous recipe did not allow lightpath 0.2.2 which skywalker needs to launch the lightpath script properly.